### PR TITLE
`mypy` Static Type Checking

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pySWATPlus/FileReader.py
+++ b/pySWATPlus/FileReader.py
@@ -11,7 +11,7 @@ def read_csv(
         path: Union[str, Path],
         skip_rows: list[int],
         usecols: list[str],
-        filter_by: dict[str, Union[Any, list[Any], re.Pattern]],
+        filter_by: dict[str, Union[Any, list[Any], re.Pattern[str]]],
         separator: str,
         encoding: str,
         engine: Literal['c', 'python'],
@@ -101,7 +101,7 @@ class FileReader:
         has_units: bool = False,
         index: Optional[str] = None,
         usecols: Optional[List[str]] = None,
-        filter_by: Dict[str, Union[Any, List[Any], re.Pattern]] = {}
+        filter_by: Dict[str, Union[Any, List[Any], re.Pattern[str]]] = {}
     ):
 
         '''

--- a/pySWATPlus/FileReader.py
+++ b/pySWATPlus/FileReader.py
@@ -9,9 +9,9 @@ import re
 
 def read_csv(
         path: Union[str, Path],
-        skip_rows: List[int],
-        usecols: List[str],
-        filter_by: Dict[str, Union[Any, List[Any], re.Pattern]],
+        skip_rows: list[int],
+        usecols: list[str],
+        filter_by: dict[str, Union[Any, list[Any], re.Pattern]],
         separator: str,
         encoding: str,
         engine: Literal['c', 'python'],
@@ -97,10 +97,10 @@ class FileReader:
 
     def __init__(
         self,
-        path: str,
+        path: str | os.PathLike,
         has_units: bool = False,
         index: Optional[str] = None,
-        usecols: List[str] = None,
+        usecols: Optional[List[str]] = None,
         filter_by: Dict[str, Union[Any, List[Any], re.Pattern]] = {}
     ):
 

--- a/pySWATPlus/PymooBestSolution.py
+++ b/pySWATPlus/PymooBestSolution.py
@@ -2,7 +2,6 @@ import numpy as np
 import itertools
 import shutil
 import multiprocessing
-from typing import Dict, List, Tuple
 
 
 class SolutionManager:

--- a/pySWATPlus/PymooBestSolution.py
+++ b/pySWATPlus/PymooBestSolution.py
@@ -13,7 +13,7 @@ class SolutionManager:
 
     def __init__(
         self
-    ):
+    ) -> None:
 
         self.X = None
         self.path = None
@@ -23,7 +23,7 @@ class SolutionManager:
     def add_solution(
         self,
         X: np.ndarray,
-        path: Dict[str, str],
+        path: dict[str, str],
         error: float
     ) -> None:
 
@@ -39,7 +39,7 @@ class SolutionManager:
 
     def get_solution(
         self
-    ) -> Tuple[np.ndarray, Dict[str, str], float]:
+    ) -> tuple[np.ndarray, dict[str, str], float]:
 
         """
         Retrieve the best solution.
@@ -51,7 +51,7 @@ class SolutionManager:
     def add_solutions(
         self,
         X_array: np.ndarray,
-        paths_array: List[Dict[str, str]],
+        paths_array: list[dict[str, str]],
         errors_array: np.ndarray
     ) -> None:
 

--- a/pySWATPlus/SWATProblem.py
+++ b/pySWATPlus/SWATProblem.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Any, Dict, List
+import typing
 from .SWATProblemMultimodel import SWATProblemMultimodel
 
 
@@ -6,13 +6,13 @@ class SWATProblem(SWATProblemMultimodel):
 
     def __init__(
         self,
-        params: Dict[str, Tuple[str, List[Tuple[str, str, float, float]]]],
-        function_to_evaluate: Callable,
+        params: dict[str, tuple[str, list[tuple[str, str, float, float]]]],
+        function_to_evaluate: typing.Callable[[dict[typing.Any, typing.Any]], tuple[float, dict[str, str]]],
         param_arg_name: str,
         n_workers: int = 1,
         parallelization: str = 'threads',
         debug: bool = False,
-        **kwargs: Dict[str, Any]
+        **kwargs: dict[str, typing.Any]
     ) -> None:
 
         """

--- a/pySWATPlus/SWATProblemMultimodel.py
+++ b/pySWATPlus/SWATProblemMultimodel.py
@@ -2,7 +2,7 @@ from pymoo.core.problem import Problem
 from .PymooBestSolution import SolutionManager
 import copy
 import numpy as np
-from typing import Optional, Callable, Tuple, Any, Dict, List
+from typing import Optional, Callable, Any
 from pymoo.optimize import minimize
 from concurrent.futures import ThreadPoolExecutor
 import multiprocessing
@@ -16,7 +16,7 @@ def minimize_pymoo(
         seed: Optional[int] = None,
         verbose: bool = False,
         callback: Optional[Callable] = None
-) -> Tuple[Optional[np.ndarray], Optional[str], Optional[float]]:
+) -> tuple[Optional[np.ndarray], Optional[str], Optional[float]]:
 
     """
     Perform optimization using the pymoo library.
@@ -64,18 +64,18 @@ class SWATProblemMultimodel(Problem):
 
     def __init__(
         self,
-        params: Dict[str, Tuple[str, List[Tuple[str, str, float, float]]]],
+        params: dict[str, tuple[str, list[tuple[str, str, float, float]]]],
         function_to_evaluate: Callable,
         param_arg_name: str,
         n_workers: int = 1,
         parallelization: str = 'threads',
-        ub_prior: Optional[List[int]] = None,
-        lb_prior: Optional[List[int]] = None,
+        ub_prior: Optional[list[int]] = None,
+        lb_prior: Optional[list[int]] = None,
         function_to_evaluate_prior: Optional[Callable] = None,
-        args_function_to_evaluate_prior: Optional[Dict[str, Any]] = None,
+        args_function_to_evaluate_prior: Optional[dict[str, Any]] = None,
         param_arg_name_to_modificate_by_prior_function: Optional[str] = None,
         debug: bool = False,
-        **kwargs: Dict[str, Any]
+        **kwargs: dict[str, Any]
     ) -> None:
 
         """
@@ -143,7 +143,7 @@ class SWATProblemMultimodel(Problem):
     def _evaluate(
         self,
         X: np.ndarray,
-        out: Dict[str, Any],
+        out: dict[str, Any],
         *args: Any,
         **kwargs: Any
     ) -> None:

--- a/pySWATPlus/SWATProblemMultimodel.py
+++ b/pySWATPlus/SWATProblemMultimodel.py
@@ -146,7 +146,7 @@ class SWATProblemMultimodel(Problem):
         out: Dict[str, Any],
         *args: Any,
         **kwargs: Any
-    ):
+    ) -> None:
 
         """
         Evaluate the objective function for a given set of input parameters.

--- a/pySWATPlus/TxtinoutReader.py
+++ b/pySWATPlus/TxtinoutReader.py
@@ -15,7 +15,7 @@ class TxtinoutReader:
 
     def __init__(
         self,
-        path: str
+        path: Union[str, os.PathLike]
     ) -> None:
 
         """

--- a/pySWATPlus/TxtinoutReader.py
+++ b/pySWATPlus/TxtinoutReader.py
@@ -298,7 +298,7 @@ class TxtinoutReader:
         has_units: bool = False,
         index: Optional[str] = None,
         usecols: Optional[List[str]] = None,
-        filter_by: Dict[str, Union[Any, List[Any], re.Pattern]] = {}
+        filter_by: dict[str, Union[Any, list[Any], re.Pattern]] = {}
     ) -> FileReader:
 
         """
@@ -451,7 +451,7 @@ class TxtinoutReader:
 
     def run_swat(
         self,
-        params: Dict[str, Tuple[str, List[Tuple[Union[None, str, List[str], re.Pattern], str, Any]]]] = {},
+        params: dict[str, tuple[str, list[tuple[Union[None, str, list[str], re.Pattern[str]], str, Any]]]] = {},
         show_output: bool = True
     ) -> str:
 
@@ -501,7 +501,7 @@ class TxtinoutReader:
 
     def run_swat_star(
         self,
-        args: Tuple[Dict[str, Tuple[str, List[Tuple[Union[None, str, List[str], re.Pattern], str, Any]]]], bool]
+        args: tuple[dict[str, tuple[str, list[tuple[Union[None, str, list[str], re.Pattern[str]], str, Any]]]], bool]
     ) -> str:
 
         """
@@ -523,7 +523,7 @@ class TxtinoutReader:
         self,
         target_dir: str,
         overwrite: bool = False,
-        params: Dict[str, Tuple[str, List[Tuple[Union[None, str, List[str], re.Pattern], str, Any]]]] = {},
+        params: dict[str, tuple[str, list[tuple[Union[None, str, list[str], re.Pattern[str]], str, Any]]]] = {},
         show_output: bool = True
     ) -> str:
 
@@ -549,7 +549,7 @@ class TxtinoutReader:
 
     def copy_and_run_star(
         self,
-        args: Tuple[str, bool, Dict[str, Tuple[str, List[Tuple[Union[None, str, List[str], re.Pattern], str, Any]]]], bool]
+        args: Tuple[str, bool, Dict[str, Tuple[str, List[Tuple[Union[None, str, List[str], re.Pattern[str]], str, Any]]]], bool]
     ) -> str:
 
         """
@@ -569,9 +569,9 @@ class TxtinoutReader:
 
     def run_parallel_swat(
         self,
-        params: List[Dict[str, Tuple[str, List[Tuple[Union[None, str, List[str], re.Pattern], str, Any]]]]],
+        params: list[dict[str, tuple[str, list[tuple[Union[None, str, list[str], re.Pattern[str]], str, Any]]]]],
         n_workers: int = 1,
-        target_dir: str = None,
+        target_dir: Optional[str] = None,
         parallelization: str = 'threads'
     ) -> List[str]:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,11 @@ testpaths = [
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "no-local-version"
+
+
+[tool.mypy]
+files = [
+    "pySWATPlus"
+]
+ignore_missing_imports = true
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pySWATPlus"
 description = "Running and calibrating default or custom SWAT+ projects with Python"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "GPL-3.0"}
 authors = [
     { name = "Joan Saló", email = "joansalograu@gmail.com" }

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -30,4 +30,6 @@ def test_get_df(
     assert df.shape[0] == 260
 
 
+def test_github():
 
+    assert str(1) == '1'


### PR DESCRIPTION
This pull request introduces support for static type checking with mypy across the `pySWATPlus` codebase. To modernize and simplify type annotations, I replaced the older style of importing generic types from the typing module—such as List, Dict, and Tuple—with the built-in generic types list, dict, and tuple, as supported in Python 3.9 and later. 

While preparing for mypy integration, I identified several common static typing issues in the code that will need to be addressed. These include errors such as 1) "Missing type parameters for generic type 'Pattern'", which occurs when using `re.Pattern` without specifying a type parameter like `re.Pattern[str]`, 2) "Missing type parameters for generic type 'ndarray'", which appears when numpy.ndarray is used without specifying the expected data types and 3) “Missing type parameters for generic type "Callable"”. These issues have been noted but not yet fixed in this pull request; they will need to be resolved to ensure full compatibility with mypy and achieve clean type-checking results.
