### PR TITLE
update pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,20 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14889320.svg)](https://doi.org/10.5281/zenodo.14889320)
 [![flake8](https://github.com/swat-model/pySWATPlus/actions/workflows/linting.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/linting.yml)
+[![pytest](https://github.com/swat-model/pySWATPlus/actions/workflows/testing.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/testing.yml)
 
 
-**pySWATPlus** is a Python package that makes working with SWAT+ models easier and more powerful. Whether you're running default setups or custom projects, this tool lets you interact with SWAT+ programmatically, so you can focus on optimizing and analyzing your models like a pro! 🚀
-
----
-
-## ✨ Key Features
-
-- **Access and Modify SWAT+ Files**: Navigate, read, modify, and write files in the `TxtInOut` folder used by SWAT+. 📂
-- **Model Calibration**: Optimize SWAT+ input parameters using the [Pymoo](https://pymoo.org/) optimization framework to get the best results. 🎯
-
----
 
 ## 📦 About
 
-pySWATPlus is an open-source software developed and maintained by [ICRA](https://icra.cat/). It’s available for download and installation via [PyPI](https://pypi.org/project/pySWATPlus/). 
+`pySWATPlus` is an open-source Python package developed and maintained by [ICRA](https://icra.cat/).
+It provides a programmatic interface to the SWAT+ model, allowing users to run simulations, modify input files, and streamline custom experimentation through the model’s `TxtInOut` folder. 
 
 ---
 
 ## 📥 Install pySWATPlus
 
-To use this package, a Python version above 3.10 is required. You can install pySWATPlus using this simple command:
+To install, run the following command with Python 3.10 or later:
 
 ````py
 pip install pySWATPlus

--- a/pySWATPlus/FileReader.py
+++ b/pySWATPlus/FileReader.py
@@ -37,8 +37,6 @@ class FileReader:
                 filter_by="plnt_typ == 'perennial'"
             )
             ```
-
-
         '''
 
         if not isinstance(path, (str, Path)):
@@ -67,16 +65,15 @@ class FileReader:
         )
 
         self.path = path
-        
+
         if has_units:
             self.units_row = self.df.iloc[0].copy()
             self.df = self.df.iloc[1:].reset_index(drop=True)
         else:
             self.units_row = None
-        
+
         if filter_by:
             self.df = self.df.query(filter_by)
-
 
     def _store_text(
         self
@@ -91,12 +88,12 @@ class FileReader:
         Returns:
         None
         '''
-        
+
         if self.units_row is not None:
             _df = pd.concat([pd.DataFrame([self.units_row]), self.df], ignore_index=True)
         else:
             _df = self.df
- 
+
         # Replace NaN with empty strings to avoid printing 'NaN'
         _df = _df.fillna('')
 
@@ -114,13 +111,11 @@ class FileReader:
                 # Format and write the header line
                 file.write(fmt.format(*_df.columns) + '\n')
                 return
-            
+
             max_lengths = _df.apply(lambda x: x.astype(str).str.len()).max()
             column_widths = {column: max_length + 3 for column, max_length in max_lengths.items()}
             data_str = _df.to_string(index=False, justify='right', col_space=column_widths)
             file.write(data_str)
-
-
 
     def _store_csv(
         self

--- a/pySWATPlus/__init__.py
+++ b/pySWATPlus/__init__.py
@@ -1,12 +1,7 @@
 from .TxtinoutReader import TxtinoutReader
 from .FileReader import FileReader
-from .types import ParamChange, ParamSpec, FileParams, ParamsType
 
 __all__ = [
     'TxtinoutReader',
-    'FileReader',
-    'ParamChange',
-    'ParamSpec',
-    'FileParams',
-    'ParamsType',
+    'FileReader'
 ]

--- a/pySWATPlus/types.py
+++ b/pySWATPlus/types.py
@@ -1,15 +1,17 @@
-# types.py
-from typing import TypedDict, Literal, List
+from typing import TypedDict, Literal
 from typing_extensions import NotRequired
 
 
-class ParamChange(TypedDict):
+class ParamChange(
+    TypedDict
+):
+
     """
     Describes a single change to apply to a parameter in a SWAT input file.
 
     Attributes:
         value (float): The value to apply to the parameter.
-        change_type (Literal['absval', 'abschg', 'pctchg'], optional): 
+        change_type (Literal['absval', 'abschg', 'pctchg'], optional):
             - `'absval'`: Use the absolute value (default).
             - `'abschg'`: Apply an absolute change.
             - `'pctchg'`: Apply a percentage change.
@@ -18,9 +20,10 @@ class ParamChange(TypedDict):
     value: float
     change_type: NotRequired[Literal['absval', 'abschg', 'pctchg']]
     filter_by: NotRequired[str]
-    
+
 
 ParamSpec = ParamChange | list[ParamChange]
+
 """
 One or more parameter changes to apply to a SWAT variable.
 
@@ -28,6 +31,7 @@ Can be a single `ParamChange` or a list of them.
 """
 
 FileParams = dict[str, bool | ParamSpec]
+
 """
 Maps a SWAT+ input file’s variables to their parameter changes.
 
@@ -51,14 +55,14 @@ Example:
 """
 
 ParamsType = dict[str, FileParams] | None
+
 """
 Top-level structure mapping SWAT input filenames to parameter modifications.
-
 
 Each file maps to:
     - `"has_units"`: Whether it contains multiple blocks (optional).
     - Variable names: Mapped to one or more parameter changes.
-    
+
 Example:
 ```python
 params = {

--- a/pySWATPlus/utils.py
+++ b/pySWATPlus/utils.py
@@ -1,39 +1,62 @@
-# file_helpers.py
 from .types import ParamsType, ParamChange
 import pandas as pd
 
-def _build_line_to_add(obj: str, daily: bool, monthly: bool, yearly: bool, avann: bool) -> str:
-    """Helper function to format lines for print.prt file"""
+
+def _build_line_to_add(
+    obj: str,
+    daily: bool,
+    monthly: bool,
+    yearly: bool,
+    avann: bool
+) -> str:
+
+    """
+    Helper function to format lines for print.prt file
+    """
+
     print_periodicity = {
         'daily': daily,
         'monthly': monthly,
         'yearly': yearly,
         'avann': avann,
     }
-    
+
     arg_to_add = obj.ljust(29)
     for value in print_periodicity.values():
         periodicity = 'y' if value else 'n'
         arg_to_add += periodicity.ljust(14)
-    
+
     return arg_to_add.rstrip() + '\n'
 
-def _apply_param_change(df: pd.DataFrame, param_name: str, change: ParamChange) -> None:
-    """Apply a single parameter change to a DataFrame"""
+
+def _apply_param_change(
+    df: pd.DataFrame,
+    param_name: str,
+    change: ParamChange
+) -> None:
+
+    """
+    Apply a single parameter change to a DataFrame
+    """
+
     value = change['value']
     change_type = change['change_type']
     filter_by = change.get('filter_by')
-    
+
     mask = df.query(filter_by).index if filter_by else df.index
-    
+
     if change_type == 'absval':
         df.loc[mask, param_name] = value
     elif change_type == 'abschg':
         df.loc[mask, param_name] += value
     elif change_type == 'pctchg':
         df.loc[mask, param_name] *= (1 + value / 100)
-        
-def _validate_params(params: ParamsType) -> None:
+
+
+def _validate_params(
+    params: ParamsType
+) -> None:
+
     """
     Validate the structure and values of SWAT parameter modification input.
 
@@ -48,6 +71,7 @@ def _validate_params(params: ParamsType) -> None:
     -------
     TypeError or ValueError if validation fails.
     """
+
     if params is None:
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/swat-model/pySWATPlus"
-"Documentation" = "https://optidamtool.readthedocs.io/en/latest/"
-
-Homepage = "https://github.com/swat-model/pySWATPlus"
-Documentation = https://swat-model.github.io/pySWATPlus/"
+Documentation = "https://swat-model.github.io/pySWATPlus/"
 
 [tool.setuptools]
 packages = ["pySWATPlus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 ]
 keywords = [
     "SWAT+",
+    "simulation",
     "hydrology",
     "watershed"
 ]
@@ -37,8 +38,10 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/swat-model/pySWATPlus"
-Repository = "https://github.com/swat-model/pySWATPlus"
-Issues = "https://github.com/swat-model/pySWATPlus/issues"
+"Documentation" = "https://optidamtool.readthedocs.io/en/latest/"
+
+Homepage = "https://github.com/swat-model/pySWATPlus"
+Documentation = https://swat-model.github.io/pySWATPlus/"
 
 [tool.setuptools]
 packages = ["pySWATPlus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,27 +8,31 @@ description = "Running and calibrating default or custom SWAT+ projects with Pyt
 dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "GPL-3.0"}
+license = "GPL-3.0-or-later"
+license-files = ["LICEN[CS]E.*"]
 authors = [
     { name = "Joan Saló", email = "joansalograu@gmail.com" }
 ]
 keywords = [
     "SWAT+",
     "hydrology",
-    "calibration",
     "watershed"
 ]
 classifiers = [
+    "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",
 	"Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    "Operating System :: OS Independent"
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering",
+	"Topic :: Scientific/Engineering :: Hydrology"
 ]
 dependencies = [
     "pandas",
+    "typing-extensions"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pandas
+typing-extensions

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -30,6 +30,7 @@ def test_get_df(
     assert df.shape[0] == 260
 
 
-
 def test_github():
+
+    # regular GitHub trigger test function when no code is changed
     assert str(1) == '1'


### PR DESCRIPTION
Update the pyproject.toml file to use the new license format as recommended by [guidelines](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license). The license field can no longer be specified solely as a classifier, as this will cause an error when running python -m build locally. Additionally, the keyword calibration has been replaced with simulation to better reflect the project's focus. The typing-extensions package has been added as a new dependency. New PyPI classifiers have been included to indicate development status, intended audience, and relevant topics. A URL for the project documentation has also been added to improve package metadata.