### PR TITLE
fixing code for static type check

### DIFF
--- a/pySWATPlus/FileReader.py
+++ b/pySWATPlus/FileReader.py
@@ -1,5 +1,5 @@
-import pandas as pd
-from pathlib import Path
+import pandas
+import pathlib
 import typing
 
 
@@ -7,7 +7,7 @@ class FileReader:
 
     def __init__(
         self,
-        path: str | Path,
+        path: str | pathlib.Path,
         has_units: bool = False,
         usecols: typing.Optional[list[str]] = None,
         filter_by: typing.Optional[str] = None
@@ -26,7 +26,7 @@ class FileReader:
             TypeError: If there's an issue reading the file or if the resulting DataFrame is not of type pandas.DataFrame.
 
         Attributes:
-            df (pd.DataFrame): a dataframe containing the data from the file.
+            df (pandas.DataFrame): a dataframe containing the data from the file.
 
         Example:
             ```python
@@ -39,10 +39,10 @@ class FileReader:
             ```
         '''
 
-        if not isinstance(path, (str, Path)):
+        if not isinstance(path, (str, pathlib.Path)):
             raise TypeError("path must be a string or Path object")
 
-        path = Path(path).resolve()
+        path = pathlib.Path(path).resolve()
 
         if not path.is_file():
             raise FileNotFoundError("file does not exist")
@@ -58,10 +58,10 @@ class FileReader:
         with open(path, 'r', encoding='latin-1') as file:
             self.header_file = file.readline()
 
-        self.df = pd.read_fwf(
+        self.df = pandas.read_fwf(
             path,
             skiprows=skip_rows,
-            usecols=usecols,
+            usecols=usecols
         )
 
         self.path = path
@@ -89,7 +89,7 @@ class FileReader:
         '''
 
         if self.units_row is not None:
-            _df = pd.concat([pd.DataFrame([self.units_row]), self.df], ignore_index=True)
+            _df = pandas.concat([pandas.DataFrame([self.units_row]), self.df], ignore_index=True)
         else:
             _df = self.df
 

--- a/pySWATPlus/types.py
+++ b/pySWATPlus/types.py
@@ -1,9 +1,9 @@
-from typing import TypedDict, Literal
-from typing_extensions import NotRequired
+import typing
+import typing_extensions
 
 
 class ParamChange(
-    TypedDict
+    typing.TypedDict
 ):
     """
     Describes a single change to apply to a parameter in a SWAT input file.
@@ -17,8 +17,8 @@ class ParamChange(
         filter_by (str, optional): Pandas `.query()` string to filter the dataframe rows.
     """
     value: float
-    change_type: NotRequired[Literal['absval', 'abschg', 'pctchg']]
-    filter_by: NotRequired[str]
+    change_type: typing_extensions.NotRequired[typing.Literal['absval', 'abschg', 'pctchg']]
+    filter_by: typing_extensions.NotRequired[str]
 
 
 ParamSpec = ParamChange | list[ParamChange]

--- a/tests/sample_data/print.prt
+++ b/tests/sample_data/print.prt
@@ -8,7 +8,7 @@ n             n             n
 crop_yld      mgtout        hydcon        fdcout        
 b             n             n             n             
 objects                  daily       monthly        yearly         avann  
-basin_wb                     n             n             y             y  
+basin_wb                     n             y             y             n
 basin_nb                     n             n             y             y  
 basin_ls                     n             n             y             y  
 basin_pw                     n             n             y             y  

--- a/tests/test_txtinoutreader.py
+++ b/tests/test_txtinoutreader.py
@@ -18,6 +18,27 @@ def txtinout_reader():
     yield txtinout_reader
 
 
+def test_enable_object_in_print_prt(
+    txtinout_reader
+):
+
+    # pass test for enable object for printing
+    txtinout_reader.enable_object_in_print_prt(
+        obj='basin_wb',
+        daily=False,
+        monthly=True,
+        yearly=True,
+        avann=False
+    )
+    output_file = os.path.join(str(txtinout_reader.root_folder), 'print.prt')
+    with open(output_file, 'r') as read_output:
+        target_line = read_output.readlines()[10]
+    assert ' y' in target_line
+    assert target_line.count(' y') == 2
+    assert ' n' in target_line
+    assert target_line.count(' n') == 2
+
+
 def test_set_begin_and_end_year(
     txtinout_reader
 ):


### PR DESCRIPTION
- Change in private function `_run_swat` to fix static type checking issues and remove FileNotFoundError, as it is already handled during the initialization of the `TxtinoutReader` class instance.

- Updated import style `from from module import method` to `import module` for better traceability and clarity.

- Added a new test function, increasing overall code coverage to nearly 50%.