### PR TITLE
Pull request for integration with `Codecov` anf `Read the Docs`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ on:
       - '**/*.py'  # Trigger for changes in Python files
 
 jobs:
-  tests:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,62 +32,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt  # Install dependencies
-        pip install coverage pytest
 
     - name: Run tests with pytest
       run: |
-          coverage run -m pytest
-          coverage xml -o coverage.xml
-          mv .coverage .coverage.${{ matrix.python-version }}
-          
-    - name: Upload coverage data
-      uses: actions/upload-artifact@v4
+        export PYTHONPATH=$(pwd)
+        pytest -rA -Wignore::DeprecationWarning --cov=pySWATPlus --cov-report=xml  # Run tests and generate coverage report in XML format
+
+    - name: Upload coverage to Codecov  # Upload coverage report to Codecov
+      uses: codecov/codecov-action@v4.2.0
       with:
-        name: coverage-data-${{ matrix.python-version }}
-        path: |
-          .coverage.${{ matrix.python-version }}
-          coverage.xml
-        include-hidden-files: true
-        if-no-files-found: error
+        token: ${{ secrets.CODECOV_TOKEN }}  # This secret token should be added in your repository settings
 
-  coverage:
-      name: Combine & check coverage
-      if: always()
-      needs: tests
-      runs-on: ubuntu-latest
-
-      steps:
-        - uses: actions/checkout@v4
-
-        - uses: actions/setup-python@v5
-          with:
-            python-version: "3.13"
-
-        - name: Download coverage data
-          uses: actions/download-artifact@v4
-          with:
-            pattern: coverage-data-*
-            merge-multiple: true
-            path: coverage-data
-
-        - name: Combine and check coverage
-          run: |
-            pip install coverage[toml]
-
-            # Move all coverage files into root
-            find coverage-data -name ".coverage.*" -exec mv {} . \;
-
-            coverage combine
-            coverage html --skip-covered --skip-empty
-
-            echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
-            coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-
-            coverage report --fail-under=100
-
-        - name: Upload HTML report if check failed
-          if: ${{ failure() }}
-          uses: actions/upload-artifact@v4
-          with:
-            name: html-report
-            path: htmlcov

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: latest
+
+# Build documentation with Mkdocs
+mkdocs:
+   configuration: mkdocs.yml
+
+# declare the Python requirements required to build your documentation
+python:
+  install:
+    - requirements: docs/requirements-docs.txt
+
+formats:
+  - pdf
+  - epub
+        
+ 
+
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![flake8](https://github.com/swat-model/pySWATPlus/actions/workflows/linting.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/linting.yml)
 [![mypy](https://github.com/swat-model/pySWATPlus/actions/workflows/typing.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/typing.yml)
 [![pytest](https://github.com/swat-model/pySWATPlus/actions/workflows/testing.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/testing.yml)
+[![codecov](https://codecov.io/gh/debpal/pySWATPlus/graph/badge.svg?token=0XJ89FRID9)](https://codecov.io/gh/debpal/pySWATPlus)
 
 ![GitHub last commit](https://img.shields.io/github/last-commit/swat-model/pySWATPlus)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/t/swat-model/pySWATPlus)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # pySWATPlus
 
 
-
-
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16380058.svg)](https://doi.org/10.5281/zenodo.16380058)
 ![PyPI - Version](https://img.shields.io/pypi/v/pySWATPlus)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pySWATPlus)
 ![PyPI - Status](https://img.shields.io/pypi/status/pySWATPlus)
 
-![Pepy Total Downloads](https://img.shields.io/pepy/dt/pySWATPLus)
 [![flake8](https://github.com/swat-model/pySWATPlus/actions/workflows/linting.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/linting.yml)
 [![mypy](https://github.com/swat-model/pySWATPlus/actions/workflows/typing.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/typing.yml)
 [![pytest](https://github.com/swat-model/pySWATPlus/actions/workflows/testing.yml/badge.svg)](https://github.com/swat-model/pySWATPlus/actions/workflows/testing.yml)
@@ -20,9 +17,9 @@
 ![GitHub forks](https://img.shields.io/github/forks/swat-model/pySWATPlus)
 ![GitHub Created At](https://img.shields.io/github/created-at/swat-model/pySWATPlus)
 
-
+![Read the Docs](https://img.shields.io/readthedocs/pySWATPlus)
+![Pepy Total Downloads](https://img.shields.io/pepy/dt/pySWATPLus)
 ![PyPI - License](https://img.shields.io/pypi/l/pySWATPlus)
-
 
 
 ## 📦 About
@@ -30,7 +27,6 @@
 `pySWATPlus` is an open-source Python package developed and maintained by [ICRA](https://icra.cat/).
 It provides a programmatic interface to the SWAT+ model, allowing users to run simulations, modify input files, and streamline custom experimentation through the model’s `TxtInOut` folder. 
 
----
 
 ## 📥 Install pySWATPlus
 
@@ -40,17 +36,10 @@ To install, run the following command with Python 3.10 or later:
 pip install pySWATPlus
 ````
 
----
 
 ## 📚 Documentation
 
-For detailed documentation, tutorials, and examples, visit the **[pySWATPlus documentation](https://swat-model.github.io/pySWATPlus/)**. The documentation includes:
-
-- **[Getting Started](https://swat-model.github.io/pySWATPlus/examples/basic_examples/)**: A beginner-friendly guide to setting up and running your first SWAT+ project.
-- **[API Reference](https://swat-model.github.io/pySWATPlus/api/txtinoutreader/)**: Comprehensive documentation of all functions, input arguments, and usage examples.
-  - **[TxtinoutReader](https://swat-model.github.io/pySWATPlus/api/txtinoutreader/)**: Work with SWAT+ input and output files.
-  - **[FileReader](https://swat-model.github.io/pySWATPlus/api/filereader/)**: Read and manipulate SWAT+ files.
----
+For a guide to setting up first SWAT+ project and other functionalities with examples, refere to the **[pySWATPlus documentation](https://pyswatplus.readthedocs.io/en/latest/)**. 
 
 
 ## 📖 Citation

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,2 @@
+pandas
+typing-extensions

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,2 +1,5 @@
+mkdocs
+mkdocstrings-python
+mkdocs-jupyter
 pandas
 typing-extensions

--- a/pySWATPlus/FileReader.py
+++ b/pySWATPlus/FileReader.py
@@ -5,6 +5,11 @@ import typing
 
 class FileReader:
 
+    '''
+    Provide functionality to read, filter, and write data
+    from a TXT file located in the `TxtInOut` folder.
+    '''
+
     def __init__(
         self,
         path: str | pathlib.Path,
@@ -12,26 +17,27 @@ class FileReader:
         usecols: typing.Optional[list[str]] = None,
         filter_by: typing.Optional[str] = None
     ):
+
         '''
-        Initialize a FileReader instance to read data from a file.
+        Initialize a FileReader instance to read data from a TXT file.
 
         Parameters:
-            path (str, Path): The path to the file.
-            has_units (bool): Indicates if the file has units (default is False).
-            usecols (list[str], optional): A list of column names to read (default is None).
-            filter_by (str, optional): Pandas query string to select applicable rows (default is None).
+            path (str or Path): Path to the TXT file to be read.
+            has_units (bool, optional): If `True`, the second row of the file contains units.
+            usecols (list[str], optional): List of column names to read from the file.
+            filter_by (str, optional): A pandas query string to filter rows from the file.
 
         Raises:
-            FileNotFoundError: If the specified file does not exist.
-            TypeError: If there's an issue reading the file or if the resulting DataFrame is not of type pandas.DataFrame.
+            TypeError: If the path is not a valid string or Path, or if the file is a CSV.
+            FileNotFoundError: If the specified file path does not exist.
 
         Attributes:
-            df (pandas.DataFrame): a dataframe containing the data from the file.
+            df (pandas.DataFrame): A DataFrame containing the loaded and optionally filtered data.
 
         Example:
             ```python
             reader = FileReader(
-                'plants.plt',
+                path='C:\\users\\username\\project\\Scenarios\\Default\\TxtInOut\\plants.plt',
                 has_units=False,
                 usecols=['name', 'plnt_typ', 'gro_trig'],
                 filter_by="plnt_typ == 'perennial'"
@@ -80,11 +86,9 @@ class FileReader:
     ) -> None:
 
         '''
-        Overwrites the TXT file after converting the content DataFrame
-        to a formatted string with adjusted column widths.
-
-        Returns:
-            None
+        Overwrite the original TXT file with the modified DataFrame content.
+        If the file originally contained a unit row (below the header),
+        it will be preserved and written back as part of the output.
         '''
 
         if self.units_row is not None:

--- a/pySWATPlus/TxtinoutReader.py
+++ b/pySWATPlus/TxtinoutReader.py
@@ -12,6 +12,11 @@ logger = logging.getLogger(__name__)
 
 class TxtinoutReader:
 
+    '''
+    Provide functionality for seamless reading, editing, and writing of
+    SWAT+ model files located in the `TxtInOut` folder.
+    '''
+
     RESERVED_PARAMS: typing.Final[list[str]] = ['has_units']
     IGNORED_FILE_PATTERNS: typing.Final[tuple[str, ...]] = tuple(
         f'_{suffix}.{ext}'
@@ -23,18 +28,19 @@ class TxtinoutReader:
         self,
         path: str | pathlib.Path
     ) -> None:
-        """
-        Initialize a TxtinoutReader instance for working with SWAT+ model data.
+
+        '''
+        Create a TxtinoutReader instance for accessing SWAT+ model files.
 
         Args:
-            path (str or Path): The path to the SWAT+ model `TxtinOut` folder.
+            path (str or Path): Path to the `TxtInOut` folder, which must contain
+                exactly one SWAT+ executable `.exe` file.
 
         Raises:
-            TypeError: If the provided path is not a string or Path object,
-                    if more than one .exe file is found,
-                    or if no .exe file is found.
-            FileNotFoundError: If the folder does not exist.
-        """
+            TypeError: If the path is not a valid string or Path, or if the folder contains
+                zero or multiple `.exe` files.
+            FileNotFoundError: If the specified folder does not exist.
+        '''
 
         # check if path is a string or a path
         if not isinstance(path, (str, pathlib.Path)):
@@ -69,19 +75,23 @@ class TxtinoutReader:
         yearly: bool,
         avann: bool
     ) -> None:
-        """
-        Enable or update an object in the 'print.prt' file. If obj is not a default identifier, it will be added at the end of the file.
+
+        '''
+        Update an object in the `print.prt` file by setting its value to `True`.
+        If the object does not exist in the file, it will be added at the end.
+
+        Note:
+            This input does not provide complete control over `print.prt` outputs.
+            Some files are internally linked in the SWAT+ model and may still be
+            generated even when disabled.
 
         Args:
-            obj (str): The object name or identifier.
-            daily (bool): Flag for daily print frequency.
-            monthly (bool): Flag for monthly print frequency.
-            yearly (bool): Flag for yearly print frequency.
-            avann (bool): Flag for average annual print frequency.
-
-        Returns:
-            None
-        """
+            obj (str): The object name or identifier to update or add.
+            daily (bool): If `True`, enable daily frequency output.
+            monthly (bool): If `True`, enable monthly frequency output.
+            yearly (bool): If `True`, enable yearly frequency output.
+            avann (bool): If `True`, enable average annual frequency output.
+        '''
 
         # check if obj is object itself or file
         if pathlib.Path(obj).suffix:
@@ -116,14 +126,12 @@ class TxtinoutReader:
     ) -> None:
 
         '''
-        Modify the simulation period by updating the begin and end years in the `time.sim` file.
+        Modify the simulation period by updating
+        the begin and end years in the `time.sim` file.
 
         Parameters:
             begin (int): Beginning year of the simulation (e.g., 2010).
             end (int): Ending year of the simulation (e.g., 2016).
-
-        Returns:
-            None
         '''
 
         nth_line = 3
@@ -162,9 +170,6 @@ class TxtinoutReader:
         Args:
             warmup (int): A positive integer representing the number of years
                 the simulation will use for warm-up (e.g., 1).
-
-        Returns:
-            None
         '''
 
         time_sim_path = self.root_folder / 'print.prt'
@@ -194,15 +199,10 @@ class TxtinoutReader:
         self,
         enable: bool = True
     ) -> None:
-        """
-        Enable or disable CSV print in the 'print.prt' file.
 
-        Parameters:
-            enable (bool): True to enable CSV print, False to disable (default is True).
-
-        Returns:
-            None
-        """
+        '''
+        Enable or disable print in the `print.prt` file.
+        '''
 
         # read
         nth_line = 7
@@ -225,24 +225,20 @@ class TxtinoutReader:
     def enable_csv_print(
         self
     ) -> None:
-        """
-        Enable CSV print in the 'print.prt' file.
 
-        Returns:
-            None
-        """
+        '''
+        Enable print in the `print.prt` file.
+        '''
 
         self._enable_disable_csv_print(enable=True)
 
     def disable_csv_print(
         self
     ) -> None:
-        """
-        Disable CSV print in the 'print.prt' file.
 
-        Returns:
-            None
-        """
+        '''
+        Disable print in the `print.prt` file.
+        '''
 
         self._enable_disable_csv_print(enable=False)
 
@@ -253,18 +249,19 @@ class TxtinoutReader:
         usecols: typing.Optional[list[str]] = None,
         filter_by: typing.Optional[str] = None
     ) -> FileReader:
-        """
+
+        '''
         Register a file to work with in the SWAT+ model.
 
         Parameters:
-            filename (str): The name of the file to register.
-            has_units (bool): Indicates if the file has units information (default is False).
-            usecols (List[str], optional): A list of column names to read (default is None).
-            filter_by (str, optional): Pandas query string to select applicable rows (default is None).
+            filename (str): Path to the file to register, located in the `TxtInOut` folder.
+            has_units (bool): If True, the second row of the file contains units.
+            usecols (list[str]): List of column names to read from the file.
+            filter_by (str): A pandas query string to filter rows from the file.
 
         Returns:
             FileReader: A FileReader instance for the registered file.
-        """
+        '''
 
         file_path = self.root_folder / filename
 
@@ -274,18 +271,11 @@ class TxtinoutReader:
         self,
         target_dir: str | pathlib.Path,
     ) -> str:
-        """
-        Prepare a working directory containing the necessary SWAT+ model files.
 
-        This function copies the contents of the SWAT model input folder (`self.root_folder`)
-        to a target directory.
-
-        Parameters:
-            target_dir (str or Path): Destination directory for the SWAT model files.
-
-        Returns:
-            str: The path to the directory where the SWAT files were copied.
-        """
+        '''
+        Copy the required contents from the input folder associated with this
+        `TxtinoutReader` instance to a target directory for SWAT+ simulation.
+        '''
 
         dest_path = pathlib.Path(target_dir)
 
@@ -300,16 +290,10 @@ class TxtinoutReader:
     def _run_swat(
         self,
     ) -> None:
-        """
+
+        '''
         Run the SWAT+ simulation.
-
-        Returns:
-            None
-
-        Raises:
-            subprocess.CalledProcessError: If the SWAT executable fails
-            FileNotFoundError: If the SWAT executable is not found
-        """
+        '''
 
         # Run simulation
         try:
@@ -347,11 +331,12 @@ class TxtinoutReader:
         self,
         params: ParamsType = None,
     ) -> pathlib.Path:
-        """
+
+        '''
         Run the SWAT+ simulation with optional parameter changes.
 
         Args:
-            params (ParamsType, optional): Nested dictionary specifying parameter changes to apply.
+            params (ParamsType): Nested dictionary specifying parameter changes to apply.
 
                 The `params` dictionary should follow this structure:
 
@@ -372,8 +357,11 @@ class TxtinoutReader:
                 }
                 ```
 
+        Raises:
+            subprocess.CalledProcessError: If the SWAT+ executable fails.
+
         Returns:
-            str: The path where the SWAT simulation was executed.
+            pathlib.Path: Path where the SWAT+ simulation was executed.
 
         Example:
             ```python
@@ -389,7 +377,7 @@ class TxtinoutReader:
 
             reader.run_swat(params)
             ```
-        """
+        '''
 
         _params = params or {}
 
@@ -437,13 +425,17 @@ class TxtinoutReader:
         target_dir: str | pathlib.Path,
         params: ParamsType = None,
     ) -> pathlib.Path:
-        """
-        Copy the SWAT+ model files to a specified directory, modify input parameters, and run the simulation.
+
+        '''
+        Run the SWAT+ model in a specified directory, with optional parameter modifications.
+        This method copies the necessary input files from the current project into the
+        given `target_dir`, applies any parameter changes specified in `params`, and
+        executes the SWAT+ simulation there.
 
         Args:
-            target_dir (str or Path): Path to the directory where the SWAT model files will be copied.
+            target_dir (str or Path): Path to the directory where the simulation will be done.
 
-            params (ParamsType, optional): Nested dictionary specifying parameter changes.
+            params (ParamsType): Nested dictionary specifying parameter changes.
 
                 The `params` dictionary should follow this structure:
 
@@ -464,8 +456,11 @@ class TxtinoutReader:
                 }
                 ```
 
+        Raises:
+            subprocess.CalledProcessError: If the SWAT+ executable fails.
+
         Returns:
-            str: The path to the directory where the SWAT simulation was executed.
+            pathlib.Path: The path to the directory where the SWAT+ simulation was executed.
 
         Example:
             ```python
@@ -485,7 +480,7 @@ class TxtinoutReader:
                     params=params
                 )
             ```
-        """
+        '''
 
         # Validate target_dir
         if not isinstance(target_dir, (str, pathlib.Path)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.10"
 license = "GPL-3.0-or-later"
 license-files = ["LICEN[CS]E.*"]
 authors = [
-    { name = "Joan Saló", email = "joansalograu@gmail.com" }
+    {name = "Joan Saló", email = "joansalograu@gmail.com"},
+    {name = "Debasish Pla", email = "bestdebasish@gmail.com"}
 ]
 keywords = [
     "SWAT+",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0-or-later"
 license-files = ["LICEN[CS]E.*"]
 authors = [
     {name = "Joan Saló", email = "joansalograu@gmail.com"},
-    {name = "Debasish Pla", email = "bestdebasish@gmail.com"}
+    {name = "Debasish Pal", email = "bestdebasish@gmail.com"}
 ]
 keywords = [
     "SWAT+",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/swat-model/pySWATPlus"
-Documentation = "https://swat-model.github.io/pySWATPlus/"
+Documentation = "https://pyswatplus.readthedocs.io/en/latest/"
 
 [tool.setuptools]
 packages = ["pySWATPlus"]

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -86,4 +86,4 @@ def test_error() -> None:
 def test_github() -> None:
 
     # regular GitHub trigger test function when no code is changed
-    assert str(4) == '4'
+    assert str(1) == '1'


### PR DESCRIPTION
- Update `testing.yml` to integrate with `Codecov`.

- Add badge for `Codecov` to the `README`.

- Configure documentation with `Read the Docs`, eliminating the need to maintain `github.io`.

- Create `.readthedocs.yaml` and `requirement-docs.txt` in the `docs/` folder to configure `Read the Docs`.

- Update the documentation URL in `pyproject.toml`.

- Remove detailed docstrings from private functions and move relevant information to the corresponding public functions.

- Remove `Returns: None` from docstrings to avoid generating unnecessary tables in the documentation.

- Add badge for `docs` to the `README`.
