### PR TITLE
Added CONTRIBUTING.md inside docs folder

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,180 @@
+# Contributing to pySWATPlus
+
+Thank you for considering contributing to `pySWATPlus`, an open-source Python package to provide a programmatic interface to the SWAT+ model. We welcome contributions to enhance its functionality for navigating `TxtInOut` folders, modifying input parameters, running simulations, and performing sensitivity analysis and calibration. This document outlines how to contribute effectively.
+
+## Getting Started
+
+### Prerequisites
+
+To contribute, ensure you have the following installed:
+
+- **Python**: Version 3.10 or higher.
+- **Git**: For version control.
+- **pip** or **conda** (if using Conda environments).
+- A code editor (e.g., VS Code, PyCharm).
+
+### Development Setting
+
+- *Fork and Clone the Repository*:
+
+    - Fork the repository on GitHub by clicking the "Fork" button.
+
+    - Clone the fork to your local machine at the desired folder path:
+
+        ```bash
+        git clone https://github.com/swat-model/pySWATPlus.git
+        cd pySWATPlus
+        ```
+
+- *Create a Virtual Environment*:
+
+    - Set up a virtual environment to isolate dependencies:
+
+        ```bash
+        python -m venv venv
+        source venv/bin/activate  # On Windows: venv\Scripts\activate
+        ```
+
+    - Alternatively, use `conda`:
+
+        ```bash
+        conda create -n pySWATPlus python=3.10
+        conda activate pySWATPlus
+        ```
+
+- *Install Dependencies*:
+
+    - Install required dependencies:
+
+        ```bash
+        pip install -r requirements.txt
+        ```
+
+    - Install development dependencies:
+
+        ```bash
+        pip install flake8       # Code style check
+        pip install mypy         # Static type checking
+        pip install pytest       # Run tests
+        pip install pytest-cov   # Test coverage report
+        pip install build        # Build distribution package
+        pip install mkdocs mkdocs-material  # Documentation site generation
+        pip install mkdocstrings-python     # Documentation for Python docstrings
+        ```
+
+- *Install `pySWATPlus` in Editable Mode*:
+
+    ```bash
+    python -m build
+    pip install --editable .
+    ```
+
+- *Verify Installation*:
+
+    ```python
+    import pySWATPlus  # should execute with no error
+    ```
+
+## How to Contribute
+
+### Types of Contributions
+
+- Solve the existing [GitHub Issues](https://github.com/swat-model/pySWATPlus/issues).
+- Fix a code bug.
+- Propose a new feature.
+- Improve documenation.
+- Suggest a new idea.
+
+
+### Code and Testing Guidelines:
+
+- Modify codes for the feature you want to work.
+
+- *Test the Mdified Code*:
+
+    - Write test functions for the modified code in the `tests/` directory.  
+      Use file and function names with the prefix `test_`.
+    - Run tests and verify test coverage from the generated `cov_pySWATPlus` directory:
+
+        ```bash
+        pytest tests/
+        ```
+
+- *Test Code Style*:
+
+    - Adhere to [PEP 8](https://peps.python.org/pep-0008/) style for Python code.
+    - Run the following command to catch style issues:
+
+        ```bash
+        flake8
+        ```
+
+- *Test Type Hints*:
+
+    - Add type hints to all variables where applicable.
+    - Run the following command to check type hints:
+
+        ```bash
+        mypy
+        ```
+
+- *Test Documentation*:
+
+    - Update documentation if the changes affect usage or introduce new features.
+    - Run the following command to build documentation:
+
+        ```bash
+        mkdocs build
+        ```
+
+- If all test functions, code style checks, type hints, and documentation build successfully without any errors, the modified code is ready to be submitted.
+
+
+### Submit Contributions
+
+- *Create a Separate Branch*:
+
+    ```bash
+    git checkout -b <feature>/<your-feature-name>
+    ```
+    
+- *Commit and Push Changes*:
+
+    - Commit an individual file (recommended):
+
+        ```bash
+        git add <filename>
+        git commit -m "Add condition for robust error check"
+        git push origin <feature>/<your-feature-name>
+        ```
+
+    - Commit all changes together:
+
+        ```bash
+        git add .
+        git commit -m "Your descriptive commit message"
+        git push origin <feature>/<your-feature-name>
+        ```
+
+### *Submit a Pull Request (PR)*
+
+- Create a PR on GitHub from your branch `<feature>/<your-feature-name>`.
+- Describe your changes, including their purpose and impact, and reference any open issues if applicable (e.g., `fixes #123`).
+- Ensure the pull request passes all CI/CD workflows.
+
+### Code Review Process
+
+- Maintainers will provide feedback on your PR to improve the code.
+- Update your PR according to the feedback.
+- Maintainers will review the changes and, if satisfactory, approve the PR for merging.
+
+
+## Code of Conduct
+
+Please follow our [Code of Conduct](https://github.com/swat-model/pySWATPlus/blob/main/CODE_OF_CONDUCT.md) to maintain a welcoming and inclusive environment for all contributors.
+
+
+## Further Queries
+
+For any help or clarification, contact the maintainers via [GitHub Issues](https://github.com/swat-model/pySWATPlus/issues).  
+Thank you for contributing to `pySWATPlus`!


### PR DESCRIPTION
Thank you for adding `CONTRIBUTING.md` to the repository.  

As a standard practice, contribution guidelines should also be included in the documentation. I have refined your write-up and added it to the documentation.  

We now have two options:  

1. **Keep `CONTRIBUTING.md` in the root directory:**  
   - This requires maintaining two files (root and docs).  

2. **Move `CONTRIBUTING.md` to `docs/CONTRIBUTING.md` only:**  
   - This way, we maintain a single source of truth, and it will be reflected in the documentation.  
