### PR TITLE
Improve Static Type Checks and Error Handling in TxtinoutReader

### DIFF
--- a/pySWATPlus/base_sensitivity_analyser.py
+++ b/pySWATPlus/base_sensitivity_analyser.py
@@ -234,7 +234,7 @@ class BaseSensitivityAnalyzer(ABC):
         var_names: list[str],
         var_bounds: list[list[float]],
         sample_number: int
-    ) -> tuple[dict[str, typing.Any], numpy.ndarray, numpy.ndarray, int]:
+    ) -> tuple[dict[str, typing.Any], numpy.typing.NDArray[numpy.float64], numpy.typing.NDArray[numpy.float64], int]:
         '''
         Prepare Sobol samples for sensitivity analysis.
         '''
@@ -261,7 +261,7 @@ class BaseSensitivityAnalyzer(ABC):
 
     @staticmethod
     def _collect_sobol_results(
-        sample_array: numpy.ndarray,
+        sample_array: numpy.typing.NDArray[numpy.float64],
         var_names: list[str],
         cpu_dict: dict[tuple[float, ...], dict[str, typing.Any]],
         problem_dict: dict[str, typing.Any],
@@ -326,7 +326,7 @@ class BaseSensitivityAnalyzer(ABC):
     def _setup_simulation_directory(
         track_sim: int,
         num_sim: int,
-        var_array: numpy.ndarray,
+        var_array: numpy.typing.NDArray[numpy.float64],
         simulation_folder: pathlib.Path
     ) -> tuple[pathlib.Path, dict[str, typing.Any]]:
         '''

--- a/pySWATPlus/validators.py
+++ b/pySWATPlus/validators.py
@@ -1,7 +1,69 @@
-from .types import ParameterModel, ParameterBoundedModel
 import pandas
 import pathlib
+import typing
+import types
 from datetime import datetime
+from .types import ParameterModel, ParameterBoundedModel
+
+
+def _variable_origin_static_type(
+    vars_types: dict[str, typing.Any],
+    vars_values: dict[str, typing.Any]
+) -> None:
+    '''
+    Validates input variables against their expected types.
+    '''
+
+    # iterate name and type of method variables
+    for v_name, v_type in vars_types.items():
+        # continute if varibale name is return
+        if v_name == 'return':
+            continue
+        # get origin type and value of the variable
+        type_origin = typing.get_origin(v_type)
+        type_value = vars_values[v_name]
+        # if origin type in None
+        if type_origin is None:
+            if not isinstance(type_value, v_type):
+                raise TypeError(
+                    f'Expected "{v_name}" to be "{v_type.__name__}", but got type "{type(type_value).__name__}"'
+                )
+        # if origin type in not None
+        else:
+            # if origin type is a Union
+            if type_origin in (typing.Union, types.UnionType):
+                # get argument types
+                type_args = tuple(
+                    typing.get_origin(arg) or arg for arg in typing.get_args(v_type)
+                )
+                if not isinstance(type_value, type_args):
+                    type_expect = [t.__name__ for t in type_args]
+                    raise TypeError(
+                        f'Expected "{v_name}" to be one of {type_expect}, but got type "{type(type_value).__name__}"'
+                    )
+            # if origin type in not a Union
+            else:
+                if not isinstance(type_value, type_origin):
+                    raise TypeError(
+                        f'Expected "{v_name}" to be "{type_origin.__name__}", but got type "{type(type_value).__name__}"'
+                    )
+
+    return None
+
+
+def _path_directory(
+    path: pathlib.Path
+) -> None:
+    '''
+    Validates path of the direcotry.
+    '''
+
+    if not path.is_dir():
+        raise NotADirectoryError(
+            f'Invalid target_dir path: {str(path)}'
+        )
+
+    return None
 
 
 def _validate_date_str(


### PR DESCRIPTION
This pull request includes:

- Introduced `_variable_origin_static_type` for static type checking of input variable origins  
- Added `_variable_origin_static_type` in several methods of the `TxtinoutReader` class for general static type checking  
- Removed error statements for `time.sim` and `print.prt` since errors are automatically raised by `with open('time.sim') as f` if the file does not exist  
- Removed duplicate error checking in test functions for the `TxtinoutReader` class  
- Removed `mkdir` from the `copy_required_files` function because it is risky: `pathlib.Path(target_dir).resolve()` returns an absolute path and may create files in unintended locations  
